### PR TITLE
Small AMQP API improvements

### DIFF
--- a/src/main/java/io/vertx/amqp/AmqpConnection.java
+++ b/src/main/java/io/vertx/amqp/AmqpConnection.java
@@ -154,4 +154,9 @@ public interface AmqpConnection {
    */
   Future<AmqpSender> createAnonymousSender();
 
+  /**
+   * @return whether the connection has been disconnected.
+   */
+  boolean isDisconnected();
+
 }

--- a/src/main/java/io/vertx/amqp/AmqpSender.java
+++ b/src/main/java/io/vertx/amqp/AmqpSender.java
@@ -83,4 +83,9 @@ public interface AmqpSender extends WriteStream<AmqpMessage> {
    * @return the connection having created the sender.
    */
   AmqpConnection connection();
+
+  /**
+   * @return the remaining credit, 0 is none.
+   */
+  long remainingCredits();
 }

--- a/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
@@ -411,7 +411,22 @@ public class AmqpConnectionImpl implements AmqpConnection {
     return promise.future();
   }
 
-  ProtonConnection unwrap() {
+  @Override
+  public boolean isDisconnected() {
+    ProtonConnection current = this.connection.get();
+    if (current != null) {
+      return current.isDisconnected();
+    } else {
+      return true;
+    }
+  }
+
+  /**
+   * Allows retrieving the underlying {@link ProtonConnection}.
+   *
+   * @return the underlying connection
+   */
+  public ProtonConnection unwrap() {
     return this.connection.get();
   }
 

--- a/src/main/java/io/vertx/amqp/impl/AmqpSenderImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpSenderImpl.java
@@ -284,4 +284,9 @@ public class AmqpSenderImpl implements AmqpSender {
   public String address() {
     return sender.getRemoteAddress();
   }
+
+  @Override
+  public long remainingCredits() {
+    return ((ProtonSenderImpl) sender).getRemoteCredit();
+  }
 }


### PR DESCRIPTION
Allow retrieving the underlying connection, credits, and checking if the connection is disconnected.

Add methods that have been requested in Quarkus and SmallRye Reactive Messaging.

This would need to be backported to 3.9.