### PR TITLE
Establish handler to deliver to before calling deliverMessageToHandler

### DIFF
--- a/src/main/java/io/vertx/amqp/impl/AmqpReceiverImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpReceiverImpl.java
@@ -86,9 +86,6 @@ public class AmqpReceiverImpl implements AmqpReceiver {
       .setPrefetch(0);
 
     this.receiver.handler((delivery, message) -> handleMessage(new AmqpMessageImpl(message, delivery)));
-    if (this.handler != null) {
-      handler(this.handler);
-    }
 
     this.receiver.closeHandler(res -> {
       onClose(address, receiver, res, false);
@@ -161,8 +158,10 @@ public class AmqpReceiverImpl implements AmqpReceiver {
   private void handleMessage(AmqpMessageImpl message) {
     boolean schedule = false;
 
+    Handler<AmqpMessage> h;
     synchronized (this) {
-      if(handler == null || demand == 0L) {
+      h = handler;
+      if(h == null || demand == 0L) {
         // Buffer message until we aren't paused
         buffered.add(message);
         return;
@@ -179,7 +178,7 @@ public class AmqpReceiverImpl implements AmqpReceiver {
         demand--;
       }
     }
-    deliverMessageToHandler(message);
+    deliverMessageToHandler(h, message);
 
     // schedule next delivery if appropriate, after earlier delivery to allow chance to pause etc.
     if(schedule) {
@@ -252,12 +251,7 @@ public class AmqpReceiverImpl implements AmqpReceiver {
     return this;
   }
 
-  private void deliverMessageToHandler(AmqpMessageImpl message) {
-    Handler<AmqpMessage> h;
-    synchronized (this) {
-      h = handler;
-    }
-
+  private void deliverMessageToHandler(Handler<AmqpMessage> h, AmqpMessageImpl message) {
     try {
       h.handle(message);
       if (autoAck) {
@@ -282,10 +276,12 @@ public class AmqpReceiverImpl implements AmqpReceiver {
 
     if (schedule) {
       connection.runOnContext(v -> {
+        Handler<AmqpMessage> h;
         AmqpMessageImpl message = null;
 
         synchronized (this) {
-          if (demand > 0L) {
+          h = handler;
+          if (h != null && demand > 0L) {
             message = buffered.poll();
             if (demand != Long.MAX_VALUE && message != null) {
               demand--;
@@ -295,7 +291,7 @@ public class AmqpReceiverImpl implements AmqpReceiver {
 
         if (message != null) {
           // Delivering outside the synchronized block
-          deliverMessageToHandler(message);
+          deliverMessageToHandler(h, message);
 
           // Schedule a delivery for a further buffered message if any
           scheduleBufferedMessageDelivery();


### PR DESCRIPTION
I noticed some further small issues while looking at #39.

The code makes various decisions under synchronization about whether to deliver, and then calls another method to actually do the delivery - which only then grabs the handler after re-synchronizing. Technically the handler might not be there any longer at this point, so it could NPE having removed the 'demand' already, and that message wouldn't be delivered later, a not dissimilar situation as the original report.

It seems simpler to just get the handler during the first synchronized area when deciding if there is any delivery to try or not. Avoids any such issues, and saves doing the second synchronization.

This also removes a redundant handler(..) call within the constructor; the null check will mean it does nothing, as the handler isnt set until after construction.