### PR TITLE
add ability to set capabilities on the sender target terminus

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -184,6 +184,12 @@ Sets whether the link is automatically marked drained after the send queue drain
  <p>
  <code>true</code> by default.
 +++
+|[[capabilities]]`@capabilities`|`Array of String`|+++
+Sets the list of capabilities to be set on the sender target terminus.
++++
+|[[capabilitys]]`@capabilitys`|`Array of String`|+++
+Adds a capability to be set on the sender target terminus.
++++
 |[[dynamic]]`@dynamic`|`Boolean`|+++
 Sets whether the Target terminus to be used should specify it is 'dynamic',
  requesting the peer creates a node and names it with a generated address.

--- a/src/main/generated/io/vertx/amqp/AmqpSenderOptionsConverter.java
+++ b/src/main/generated/io/vertx/amqp/AmqpSenderOptionsConverter.java
@@ -35,6 +35,24 @@ public class AmqpSenderOptionsConverter {
             obj.setAutoDrained((Boolean)member.getValue());
           }
           break;
+        case "capabilities":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setCapabilities(list);
+          }
+          break;
+        case "capabilitys":
+          if (member.getValue() instanceof JsonArray) {
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                obj.addCapability((String)item);
+            });
+          }
+          break;
         case "dynamic":
           if (member.getValue() instanceof Boolean) {
             obj.setDynamic((Boolean)member.getValue());
@@ -55,6 +73,11 @@ public class AmqpSenderOptionsConverter {
 
   public static void toJson(AmqpSenderOptions obj, java.util.Map<String, Object> json) {
     json.put("autoDrained", obj.isAutoDrained());
+    if (obj.getCapabilities() != null) {
+      JsonArray array = new JsonArray();
+      obj.getCapabilities().forEach(item -> array.add(item));
+      json.put("capabilities", array);
+    }
     json.put("dynamic", obj.isDynamic());
     if (obj.getLinkName() != null) {
       json.put("linkName", obj.getLinkName());

--- a/src/main/java/io/vertx/amqp/AmqpSenderOptions.java
+++ b/src/main/java/io/vertx/amqp/AmqpSenderOptions.java
@@ -15,6 +15,10 @@
  */
 package io.vertx.amqp;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
@@ -27,6 +31,7 @@ public class AmqpSenderOptions {
   private String linkName;
   private boolean dynamic;
   private boolean autoDrained = true;
+  private List<String> capabilities = new ArrayList<>();
 
   public AmqpSenderOptions() {
 
@@ -102,6 +107,44 @@ public class AmqpSenderOptions {
    */
   public AmqpSenderOptions setAutoDrained(boolean autoDrained) {
     this.autoDrained = autoDrained;
+    return this;
+  }
+
+  /**
+   * Gets the list of capabilities to be set on the sender target terminus.
+   *
+   * @return the list of capabilities, empty if none.
+   */
+  public List<String> getCapabilities() {
+    if (capabilities == null) {
+      return new ArrayList<>();
+    }
+    return capabilities;
+  }
+
+  /**
+   * Sets the list of capabilities to be set on the sender target terminus.
+   *
+   * @param capabilities the set of target capabilities.
+   * @return the options
+   */
+  public AmqpSenderOptions setCapabilities(List<String> capabilities) {
+    this.capabilities = capabilities;
+    return this;
+  }
+
+  /**
+   * Adds a capability to be set on the sender target terminus.
+   *
+   * @param capability the target capability to add, must not be {@code null}
+   * @return the options
+   */
+  public AmqpSenderOptions addCapability(String capability) {
+    Objects.requireNonNull(capability, "The capability must not be null");
+    if (this.capabilities == null) {
+      this.capabilities = new ArrayList<>();
+    }
+    this.capabilities.add(capability);
     return this;
   }
 }

--- a/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
@@ -20,10 +20,12 @@ import io.vertx.core.*;
 import io.vertx.proton.*;
 import io.vertx.proton.impl.ProtonConnectionImpl;
 import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Target;
 import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
 import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
 import org.apache.qpid.proton.engine.EndpointState;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -379,16 +381,25 @@ public class AmqpConnectionImpl implements AmqpConnection {
 
           sender = conn.createSender(address, opts);
           sender.setAutoDrained(options.isAutoDrained());
+
+          configureTheTarget(options, sender);
         } else {
           sender = conn.createSender(address);
         }
-
-        // TODO durable?
 
         AmqpSenderImpl.create(sender, this, completionHandler);
       }
     });
     return this;
+  }
+
+  private void configureTheTarget(AmqpSenderOptions senderOptions, ProtonSender sender) {
+    Target target = (org.apache.qpid.proton.amqp.messaging.Target) sender.getTarget();
+
+    List<String> capabilities = senderOptions.getCapabilities();
+    if (!capabilities.isEmpty()) {
+      target.setCapabilities(capabilities.stream().map(Symbol::valueOf).toArray(Symbol[]::new));
+    }
   }
 
   @Override


### PR DESCRIPTION
The receiver options currently allow specifying capabilities to set on its source terminus details while attaching the receiver. This can be useful for using certain consumer funtionality (e.g shared subs), or for adding hints to influence a particular servers behaviour if it might choose to auto-create a node when none yet exists at the given address (e.g, indicating desire for a queue or a topic).

This PR adds the equivalent support for a sender to have particular capabilities set in its target terminus details during attach.