### PR TITLE
Dont't throw IllegalStateException in AmqpMessageImpl#isBodyNull() when body contains binary data

### DIFF
--- a/src/main/java/io/vertx/amqp/impl/AmqpMessageImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpMessageImpl.java
@@ -90,13 +90,19 @@ public class AmqpMessageImpl implements AmqpMessage {
     return null;
   }
 
+  private boolean isBodyAmqpValue() {
+    final Section body = message.getBody();
+    return body != null && body.getType() == Section.SectionType.AmqpValue;
+  }
+
   @Override
   public boolean isBodyNull() {
-    return message.getBody() == null || getAmqpValue() == null;
+    final Section body = message.getBody();
+    return body == null || isBodyAmqpValue() && ((AmqpValue) body).getValue() == null;
   }
 
   private Object getAmqpValue() {
-    if (message.getBody().getType() != Section.SectionType.AmqpValue) {
+    if (!isBodyAmqpValue()) {
       throw new IllegalStateException("The body is not an AMQP Value");
     }
     return ((AmqpValue) message.getBody()).getValue();

--- a/src/test/java/io/vertx/amqp/impl/AmqpMessageImplTest.java
+++ b/src/test/java/io/vertx/amqp/impl/AmqpMessageImplTest.java
@@ -15,8 +15,11 @@
  */
 package io.vertx.amqp.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 import org.junit.Test;
 
@@ -31,6 +34,22 @@ public class AmqpMessageImplTest {
 
     AmqpMessageImpl message = new AmqpMessageImpl(protonMsg);
     assertEquals(contentEncoding, message.contentEncoding());
+  }
+
+  @Test
+  public void testIsBodyNull() {
+
+    Message protonMsg = Message.Factory.create();
+    AmqpMessageImpl message = new AmqpMessageImpl(protonMsg);
+
+    protonMsg.setBody(null);
+    assertTrue(message.isBodyNull());
+
+    protonMsg.setBody(new AmqpValue(null));
+    assertTrue(message.isBodyNull());
+
+    protonMsg.setBody(new Data(new Binary(new byte[0])));
+    assertFalse(message.isBodyNull());
   }
 
 }


### PR DESCRIPTION
Fix vert-x3/vertx-amqp-client#53