### PR TITLE
Simplify AmqpConnectionImpl#close()

### DIFF
--- a/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
@@ -205,9 +205,9 @@ public class AmqpConnectionImpl implements AmqpConnection {
           done.handle(Future.succeededFuture());
         }
         return;
-      } else {
-        closed.set(true);
       }
+      
+      closed.set(true);
 
       Promise<Void> future = Promise.promise();
       if (done != null) {
@@ -220,10 +220,8 @@ public class AmqpConnectionImpl implements AmqpConnection {
           actualConnection
             .disconnectHandler(con -> {
               future.tryFail(getErrorMessage(con));
-              closed.set(true);
             })
             .closeHandler(res -> {
-              closed.set(true);
               if (res.succeeded()) {
                 future.tryComplete();
               } else {


### PR DESCRIPTION
Motivation:

Reduce cognitive load to understand the `AmqpConnectionImpl#close()` method.

1) The else block around the `closed.set(true);` statement in line 208 is not necessary since the corresponding if block ends with an early return statement.
2) In case the code of lines 212-249 is reached, `closed` is always set to `true`, thus there is no need to call `closed.set(true);` again in the close/disconnect handlers
