### PR TITLE
add an option to override the AMQP connection hostname value only

### DIFF
--- a/src/main/generated/io/vertx/amqp/AmqpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/amqp/AmqpClientOptionsConverter.java
@@ -36,6 +36,11 @@ public class AmqpClientOptionsConverter {
             obj.setConnectTimeout(((Number)member.getValue()).intValue());
           }
           break;
+        case "connectionHostname":
+          if (member.getValue() instanceof String) {
+            obj.setConnectionHostname((String)member.getValue());
+          }
+          break;
         case "containerId":
           if (member.getValue() instanceof String) {
             obj.setContainerId((String)member.getValue());
@@ -298,6 +303,9 @@ public class AmqpClientOptionsConverter {
 
   public static void toJson(AmqpClientOptions obj, java.util.Map<String, Object> json) {
     json.put("connectTimeout", obj.getConnectTimeout());
+    if (obj.getConnectionHostname() != null) {
+      json.put("connectionHostname", obj.getConnectionHostname());
+    }
     if (obj.getContainerId() != null) {
       json.put("containerId", obj.getContainerId());
     }

--- a/src/main/java/io/vertx/amqp/AmqpClientOptions.java
+++ b/src/main/java/io/vertx/amqp/AmqpClientOptions.java
@@ -41,6 +41,7 @@ public class AmqpClientOptions extends ProtonClientOptions {
   private String password = getFromSysOrEnv("amqp-client-password");
 
   private String containerId = UUID.randomUUID().toString();
+  private String connectionHostname = null;
 
   public AmqpClientOptions() {
     super();
@@ -58,6 +59,7 @@ public class AmqpClientOptions extends ProtonClientOptions {
     this.username = other.username;
     this.port = other.port;
     this.containerId = other.containerId;
+    this.connectionHostname = other.connectionHostname;
   }
 
   public JsonObject toJson() {
@@ -157,6 +159,28 @@ public class AmqpClientOptions extends ProtonClientOptions {
    */
   public AmqpClientOptions setContainerId(String containerId) {
     this.containerId = containerId;
+    return this;
+  }
+
+  /**
+   * Get the connection hostname override for the AMQP Open frame hostname
+   *
+   * @return the hostname override
+   */
+  public String getConnectionHostname() {
+    return connectionHostname;
+  }
+
+  /**
+   * Explicitly override the hostname value used for the AMQP Open frame.
+   *
+   * The host connected to as per {@link #setHost(String)} will be used in the Open frame by default.
+   *
+   * @param hostname the hostname override value to use as the Open frame hostname
+   * @return  current AmqpClientOptions instance
+   */
+  public AmqpClientOptions setConnectionHostname(String hostname) {
+    connectionHostname = hostname;
     return this;
   }
 

--- a/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
@@ -81,8 +81,8 @@ public class AmqpConnectionImpl implements AmqpConnection {
               this.connection.get().setContainer(options.getContainerId());
             }
 
-            if (options.getVirtualHost() != null) {
-              this.connection.get().setHostname(options.getVirtualHost());
+            if (options.getConnectionHostname() != null) {
+              this.connection.get().setHostname(options.getConnectionHostname());
             }
 
             this.connection.get()


### PR DESCRIPTION
Adds an option to override the AMQP connection Open hostname in isolation.

It is already possible to override it _and_ the SNI value with the virtualhost option, but you cant control it in isolation with vertx-amqp-client as the route to do so from vertx-proton to isnt usable here because pre-opened connections are returned on creation).