### PR TITLE
Fix wrong dispatching in the AMQP sender

### DIFF
--- a/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
@@ -169,7 +169,8 @@ public class AmqpConnectionImpl implements AmqpConnection {
   }
 
   void runWithTrampoline(Handler<Void> action) {
-    if (Vertx.currentContext() == context) {
+    // Check that we have the same context and that we are on an event loop
+    if (Vertx.currentContext() == context  && ((ContextInternal) context).nettyEventLoop().inEventLoop()) {
       action.handle(null);
     } else {
       runOnContext(action);

--- a/src/main/java/io/vertx/amqp/impl/AmqpSenderImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpSenderImpl.java
@@ -137,13 +137,6 @@ public class AmqpSenderImpl implements AmqpSender {
   }
 
   private AmqpSender doSend(AmqpMessage message, Handler<AsyncResult<Void>> acknowledgmentHandler) {
-    AmqpMessage updated;
-    if (message.address() == null) {
-      updated = AmqpMessage.create(message).address(address()).build();
-    } else {
-      updated = message;
-    }
-
     Handler<ProtonDelivery> ack = delivery -> {
       Handler<AsyncResult<Void>> handler = acknowledgmentHandler;
       if (acknowledgmentHandler == null) {
@@ -180,6 +173,13 @@ public class AmqpSenderImpl implements AmqpSender {
     }
 
     connection.runWithTrampoline(x -> {
+      AmqpMessage updated;
+      if (message.address() == null) {
+        updated = AmqpMessage.create(message).address(address()).build();
+      } else {
+        updated = message;
+      }
+
       sender.send(updated.unwrap(), ack);
 
       synchronized (AmqpSenderImpl.this) {


### PR DESCRIPTION
When sending is done from `vertx.executeBlocking`, the dispatch with a trampoline was executing the action immediately (from the worker thread), which leads to concurrency issues.

Related to https://github.com/smallrye/smallrye-reactive-messaging/issues/1541.
