### PR TITLE
Add unwrap methods to AmqpConnection, AmqpSender and AmqpReceiver classes

### DIFF
--- a/src/main/java/io/vertx/amqp/AmqpConnection.java
+++ b/src/main/java/io/vertx/amqp/AmqpConnection.java
@@ -16,10 +16,15 @@
 package io.vertx.amqp;
 
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.proton.ProtonConnection;
+import io.vertx.proton.ProtonSender;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
 
 /**
  * Once connected to the broker or router, you get a connection. This connection is automatically opened.
@@ -164,5 +169,11 @@ public interface AmqpConnection {
    * @return a future completed when the connection is closed
    */
   Future<Void> closeFuture();
+
+  /**
+   * @return the underlying ProtonConnection.
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  ProtonConnection unwrap();
 
 }

--- a/src/main/java/io/vertx/amqp/AmqpReceiver.java
+++ b/src/main/java/io/vertx/amqp/AmqpReceiver.java
@@ -16,12 +16,17 @@
 package io.vertx.amqp;
 
 import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.streams.ReadStream;
+import io.vertx.proton.ProtonReceiver;
+import io.vertx.proton.ProtonSender;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
 
 /**
  * Interface used to consume AMQP message as a stream of message.
@@ -74,4 +79,10 @@ public interface AmqpReceiver extends ReadStream<AmqpMessage> {
    * @return the connection having created the receiver.
    */
   AmqpConnection connection();
+
+  /**
+   * @return the underlying ProtonReceiver.
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  ProtonReceiver unwrap();
 }

--- a/src/main/java/io/vertx/amqp/AmqpSender.java
+++ b/src/main/java/io/vertx/amqp/AmqpSender.java
@@ -16,11 +16,15 @@
 package io.vertx.amqp;
 
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.streams.WriteStream;
+import io.vertx.proton.ProtonSender;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
 
 /**
  * AMQP Sender interface used to send messages.
@@ -88,4 +92,10 @@ public interface AmqpSender extends WriteStream<AmqpMessage> {
    * @return the remaining credit, 0 is none.
    */
   long remainingCredits();
+
+  /**
+   * @return the underlying ProtonSender.
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  ProtonSender unwrap();
 }

--- a/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpConnectionImpl.java
@@ -479,6 +479,7 @@ public class AmqpConnectionImpl implements AmqpConnection {
    *
    * @return the underlying connection
    */
+  @Override
   public ProtonConnection unwrap() {
     return this.connection.get();
   }

--- a/src/main/java/io/vertx/amqp/impl/AmqpReceiverImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpReceiverImpl.java
@@ -357,6 +357,11 @@ public class AmqpReceiverImpl implements AmqpReceiver {
     return promise.future();
   }
 
+  @Override
+  public ProtonReceiver unwrap() {
+    return receiver;
+  }
+
   private synchronized boolean isDurable() {
     return durable;
   }

--- a/src/main/java/io/vertx/amqp/impl/AmqpSenderImpl.java
+++ b/src/main/java/io/vertx/amqp/impl/AmqpSenderImpl.java
@@ -290,4 +290,9 @@ public class AmqpSenderImpl implements AmqpSender {
   public long remainingCredits() {
     return ((ProtonSenderImpl) sender).getRemoteCredit();
   }
+
+  @Override
+  public ProtonSender unwrap() {
+    return sender;
+  }
 }

--- a/src/test/java/io/vertx/amqp/ReceiverTest.java
+++ b/src/test/java/io/vertx/amqp/ReceiverTest.java
@@ -163,6 +163,8 @@ public class ReceiverTest extends BareTestBase {
         context.assertTrue(recResult.succeeded());
         AmqpReceiver receiver = recResult.result();
 
+        context.assertNotNull(receiver.unwrap());
+
         receiver.handler(message -> list.add(message.bodyAsString()));
       });
     });

--- a/src/test/java/io/vertx/amqp/SenderTest.java
+++ b/src/test/java/io/vertx/amqp/SenderTest.java
@@ -242,6 +242,10 @@ public class SenderTest extends BareTestBase {
         sender.drainHandler(x -> {
           context
             .assertTrue(asyncSendInitialCredit.isSucceeded(), "should have been called after initial credit delay");
+
+          context.assertTrue(sender.remainingCredits() > 0);
+          context.assertNotNull(sender.unwrap());
+
           context.assertFalse(sender.writeQueueFull(), "expected write queue not to be full, we just granted credit");
 
           // Send message using the credit


### PR DESCRIPTION
These methods give access to the underlying Proton objects. In some cases, it is required to retrieve information on the links (sender/receiver) and open/close them.
The AmqpConnection unwrap method existed already but was not exposed in the interface. This commit exposes it in the interface.

Because the returned objects are not "polyglot", it uses the @GenIgnore(PERMITTED_TYPE)

