### PR TITLE
Test with JDK 25

### DIFF
--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -27,6 +27,8 @@ jobs:
             jdk: 8
           - os: ubuntu-latest
             jdk: 17
+          - os: ubuntu-latest
+            jdk: 25
     uses: ./.github/workflows/ci.yml
     with:
       branch: 4.x

--- a/.github/workflows/ci-matrix-5.x.yml
+++ b/.github/workflows/ci-matrix-5.x.yml
@@ -30,6 +30,8 @@ jobs:
             jdk: 11
           - os: ubuntu-latest
             jdk: 21
+          - os: ubuntu-latest
+            jdk: 25
     uses: ./.github/workflows/ci.yml
     with:
       branch: ${{ inputs.branch }}


### PR DESCRIPTION
Makes sure Vert.x AMQP Client test suite passes with Java 25, in all supported versions.